### PR TITLE
Fix indentation of match clauses.

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -3261,6 +3261,7 @@ Returns t iff skipped to indentation."
           (+ (tuareg-add-default-indent leading-operator)
              (current-column)
              (- tuareg-pipe-extra-unindent)
+             tuareg-match-clause-indent
              tuareg-default-indent))
          (t
           (+ (tuareg-paren-or-indentation-column)


### PR DESCRIPTION
When smie is disabled, match clauses are not indented according to
`tuareg-match-clause-indent`. (Actually, the name `tuareg-match-clause-indent`
shows up only it the `defvar` for it and in `tuareg-smie-rules`.) This should
fix the problem.
