### PR TITLE
Fix inconsistent indentation of type definitions.

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -346,7 +346,7 @@ the default is 1.")
         when cond ->
       clause")
 
-(defcustom tuareg-type-indent 0 ;tuareg-default-indent
+(defcustom tuareg-type-indent tuareg-default-indent
   "*How many spaces to indent from a `type' keyword."
   :group 'tuareg :type 'integer)
 
@@ -3437,8 +3437,10 @@ Returns t iff skipped to indentation."
                        tuareg-default-indent)
                       (t (goto-char start-pos)
                          (beginning-of-line)
-                         (+ (tuareg-add-default-indent
-                             (looking-at "[ \t]*[\[|]"))
+                         ;; A first sum constructor without a preceding `|'
+                         ;; needs extra indentation to be aligned with the other
+                         ;; constructors.
+                         (+ (if (looking-at "[ \t]*[A-Z]") 2 0)
                             tuareg-type-indent))))
                ((looking-at tuareg-=-indent-regexp-1)
                 (let ((matched-string (tuareg-match-string 0)))
@@ -3520,7 +3522,8 @@ Returns t iff skipped to indentation."
 
 (defun tuareg-compute-pipe-indent (matching-kwop old-point)
   (cond
-    ((string= matching-kwop "|")
+    ((or (string= matching-kwop "|")
+         (string= matching-kwop "["))
      (tuareg-back-to-paren-or-indentation)
      (current-column))
     ((and (string= matching-kwop "=")


### PR DESCRIPTION
With `tuareg-type-indent` set to `2`, `tuareg-default-indent` to `3`,
and smie disabled, type definitions are indented like this:

```
type a =
     Bar
  | Foo

type b =
  [ `Foo
   | `Bar ]

type c =
     { foo : int }

type d =
     a * b
```

This patch fixes the indentation so that:
1. `[`, `|`, `{` and type aliases all get an indentation of
    `tuareg-type-indent` relative to `type`.
2. Even when the first constructor in a sum type is not preceded by a
    `|`, it is still aligned with the other constructors.

In other words:

```
type a =
    Bar
  | Foo

type b =
  [ `Foo
  | `Bar ]

type c =
  { foo : int }

type d =
  a * b
```
