### PR TITLE
Indentation for "fun ... ->"

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -1750,6 +1750,7 @@ Return values can be
                        (equal (nth 2 (smie-backward-sexp "|")) "with"))))
            (smie-rule-parent 2))
           ((smie-rule-parent-p "|") tuareg-match-clause-indent)
+          ((smie-rule-parent-p "fun") tuareg-fun-indent)
           (t 0)))
         ((equal token ":")
          (cond

--- a/tuareg.el
+++ b/tuareg.el
@@ -1671,6 +1671,9 @@ Return values can be
          (tuareg-smie--with-module-fields-rule)))
    ;; Special indentation for monadic >>>, >>|, and >>= operators.
    ((and (eq kind :before) (tuareg-smie--monadic-rule token)))
+   ((and (equal token "and")
+	 (smie-rule-parent-p "type"))
+    0)
    ((member token '(";" "|" "," "and" "m-and"))
     (cond
      ((and (eq kind :before) (member token '("|" ";"))


### PR DESCRIPTION
This change makes `tuareg-smie-rules` respect `tuareg-fun-indent`.
