### PR TITLE
Tuareg should report its version accurately (2.0.8 not 2.0.6)

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -96,7 +96,7 @@
   "Tuareg revision from the control system used.")
 
 (defconst tuareg-mode-version
-  (let ((version "Tuareg Version 2.0.6"))
+  (let ((version "Tuareg Version 2.0.8"))
     (if (null tuareg-mode-revision)
         version
       (concat version " (" tuareg-mode-revision ")")


### PR DESCRIPTION
Title says it all.
