### PR TITLE
mark toplevel prompt as readonly

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -2480,12 +2480,7 @@ otherwise return non-nil."
                       (put-text-property
                        (+ comint-last-input-start beg)
                        (+ comint-last-input-start end)
-                       'face 'tuareg-font-lock-error-face))))))))
-	(save-excursion
-	  (goto-char (point-max))
-	  (re-search-backward comint-prompt-regexp comint-last-output-start t)
-	  (let ((inhibit-read-only t))
-	    (put-text-property (1- (point)) (point-max) 'read-only t)))))))
+                       'face 'tuareg-font-lock-error-face))))))))))))
 
 (easy-menu-define
   tuareg-interactive-mode-menu tuareg-interactive-mode-map

--- a/tuareg.el
+++ b/tuareg.el
@@ -2526,6 +2526,7 @@ Short cuts for interactions with the toplevel:
   (set (make-local-variable 'comment-start) "(* ")
   (set (make-local-variable 'comment-end) " *)")
   (set (make-local-variable 'comment-start-skip) "(\\*+[ \t]*")
+  (set (make-local-variable 'comint-prompt-read-only) t)
 
   (tuareg--common-mode-setup)
   (when (or tuareg-interactive-input-font-lock

--- a/tuareg.el
+++ b/tuareg.el
@@ -2480,7 +2480,12 @@ otherwise return non-nil."
                       (put-text-property
                        (+ comint-last-input-start beg)
                        (+ comint-last-input-start end)
-                       'face 'tuareg-font-lock-error-face))))))))))))
+                       'face 'tuareg-font-lock-error-face))))))))
+	(save-excursion
+	  (goto-char (point-max))
+	  (re-search-backward comint-prompt-regexp comint-last-output-start t)
+	  (let ((inhibit-read-only t))
+	    (put-text-property (1- (point)) (point-max) 'read-only t)))))))
 
 (easy-menu-define
   tuareg-interactive-mode-menu tuareg-interactive-mode-map


### PR DESCRIPTION
The OCaml Toplevel prompt can be deleted accidentally while editing and next send input will fail, make it readonly by setting coming-prompt-read-only to nil? I think it should be the default behavior as most shell does.