### PR TITLE
Don't throw for non-existent ~/.opam directory

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -2365,14 +2365,15 @@ otherwise return non-nil."
 ;;                               OPAM
 
 (defconst tuareg-opam-compilers
-  (cons "~/.opam/system"
-        (directory-files "~/.opam" t "[0-9]+\\.[0-9]+\\.[0-9]+")))
+  (when (file-directory-p "~/.opam")
+    (cons "~/.opam/system"
+          (directory-files "~/.opam" t "[0-9]+\\.[0-9]+\\.[0-9]+"))))
 
 (defvar tuareg-opam
   (let ((opam (executable-find "opam")))
     (if opam opam
       (let ((opam (locate-file "bin/opam" tuareg-opam-compilers)))
-        (if (file-executable-p opam) opam)))) ; or nil
+        (and opam (file-executable-p opam) opam)))) ; or nil
   "The full path of the opam executable.")
 
 (when tuareg-opam


### PR DESCRIPTION
If ~/.opam is not found, set tuareg-opam-compilers to nil and propogate
to tuareg-opam.

Fixes https://github.com/ocaml/tuareg/issues/33.