### PR TITLE
Don't block user-reserved keybindings

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -988,10 +988,10 @@ Regexp match data 0 points to the chars."
       (define-key map [?\C-c mouse-1] 'caml-types-mouse-ignore)
       (define-key map [?\C-c down-mouse-1] 'caml-types-explore)
       ;; Trigger caml-help
-      (define-key map [?\C-c ?i] 'ocaml-add-path)
+      (define-key map [?\C-c ?\C-i] 'ocaml-add-path)
       (define-key map [?\C-c ?\[] 'ocaml-open-module)
       (define-key map [?\C-c ?\]] 'ocaml-close-module)
-      (define-key map [?\C-c ?h] 'caml-help)
+      (define-key map [?\C-c ?\C-h] 'caml-help)
       (define-key map [?\C-c ?\t] 'tuareg-complete))
     map)
   "Keymap used in Tuareg mode.")


### PR DESCRIPTION
E.g. for [caml-help](https://github.com/ocaml/tuareg/blob/fb01be152d0be25207640cb8d4beeef37e7fe7c0/tuareg.el#L994).  See the [keybinding conventions](http://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html) and in particular the second item:

> Don’t define C-c letter as a key in Lisp programs. Sequences consisting of C-c and a letter (either upper or lower case) are reserved for users; they are the only sequences reserved for users, so do not block them.
> Changing all the Emacs major modes to respect this convention was a lot of work; abandoning this convention would make that work go to waste, and inconvenience users. Please comply with it.

Seems like simply adding one more control character in front the bindings that currently go against the above convention would adequately address the problem.  I didn't update `CHANGES` to reflect what folks would need to do to restore the previous behavior, though.