### PR TITLE
Fixed point jumping in ocamldebug completion

### DIFF
--- a/ocamldebug.el
+++ b/ocamldebug.el
@@ -747,10 +747,11 @@ representation is simply concatenated with the COMMAND."
 (defun ocamldebug-call-1 (command &optional fmt arg)
   ;; Record info on the last prompt in the buffer and its position.
   (with-current-buffer ocamldebug-current-buffer
-    (goto-char (process-mark (get-buffer-process ocamldebug-current-buffer)))
+    (save-excursion
+      (goto-char (process-mark (get-buffer-process ocamldebug-current-buffer)))
       (beginning-of-line)
       (when (looking-at comint-prompt-regexp)
-      (set-marker ocamldebug-delete-prompt-marker (point))))
+        (set-marker ocamldebug-delete-prompt-marker (point)))))
   (let ((cmd (cond
 	      (arg (concat command " " (int-to-string arg)))
 	      (fmt (ocamldebug-format-command


### PR DESCRIPTION
When interacting with ocamldebug, typing a few characters, then pausing will trigger comint completion. This works great most of the time.

However, there's some quirkiness where the point jumps back to the beginning of the line just before completion triggers. When completing something unambiguous, for example, this is rather awkward.

For example, when we type 'q' for 'quit' (position of point indicated by `|`),
```
(ocd) q|
```

After a short pause, the point jumps to the beginning of the line before the completed text is inserted. This causes the text to go in the wrong place:
```
(ocd) uit |q
```

The point is [intentionally moved](https://github.com/ocaml/tuareg/blob/master/ocamldebug.el#L750-L751), presumably to ensure that the position of the prompt is kept even after the user scrolls away.

This fixes the problem by not moving the point if it is already on that line (i.e. when the user is typing). I'm not sure if this is the right way to fix this though, or if there are edge cases missed. Advice on the approach is welcome.