### PR TITLE
Fix insertion of backslashes in non-"" strings

### DIFF
--- a/tuareg_indent.el
+++ b/tuareg_indent.el
@@ -386,7 +386,7 @@ delimiters.  For synchronous programming.")
 
 (defun tuareg-in-literal-p ()
   "Return non-nil if point is inside an OCaml literal."
-  (nth 3 (syntax-ppss)))
+  (eq (nth 3 (syntax-ppss)) 34))
 
 (defun tuareg-in-comment-p ()
   "Return non-nil if point is inside or right before an OCaml comment."


### PR DESCRIPTION
This fixes the bug where backslashes are inserted on `RET` in `{| string |}` literals and embedded minor modes like [smerge-mode](https://github.com/jwiegley/emacs-release/blob/master/lisp/vc/smerge-mode.el), where they are unwanted.

This patch simply checks that the delimiter of a literal is `"` which equates to code `34`. Only auto-inserting backslashes in `""` is IMO a much better behaviour than inserting them in any string-like thing including `{| |}` literals (where they are just literal backslashes) and editing merge conflicts.

I wrote this as a patch in my init.el and when I went to submit it here I noticed #54 but that PR is enormous and over a year old and seems to be held up indefinitely. I propose this tiny patch as a way to fix the bug for now. Maybe eventually some better solution can be put in place, but this annoying little bug should be patched as soon as possible in the mean time.

@Chris00 @monnier 
