### PR TITLE
Proposal to make tuareg-eval-buffer more robust w.r.t double-colons addition

### DIFF
--- a/tuareg-site-file.el
+++ b/tuareg-site-file.el
@@ -3,8 +3,8 @@
 (add-to-list 'load-path
              (or (file-name-directory load-file-name) (car load-path)))
 
-;;;### (autoloads nil "ocamldebug" "ocamldebug.el" (22091 24718 836997
-;;;;;;  845000))
+;;;### (autoloads nil "ocamldebug" "ocamldebug.el" (22845 27808 224521
+;;;;;;  140000))
 ;;; Generated autoloads from ocamldebug.el
 
 (autoload 'ocamldebug "ocamldebug" "\
@@ -13,13 +13,13 @@ The directory containing FILE becomes the initial working directory
 and source-file directory for ocamldebug.  If you wish to change this, use
 the ocamldebug commands `cd DIR' and `directory'.
 
-\(fn PATH)" t nil)
+\(fn PGM-PATH)" t nil)
 
 (defalias 'camldebug 'ocamldebug)
 
 ;;;***
 
-;;;### (autoloads nil "tuareg" "tuareg.el" (22359 21012 24789 234000))
+;;;### (autoloads nil "tuareg" "tuareg.el" (22845 33612 205038 646000))
 ;;; Generated autoloads from tuareg.el
 (add-to-list 'auto-mode-alist '("\\.ml[ip]?\\'" . tuareg-mode))
 (add-to-list 'auto-mode-alist '("\\.eliomi?\\'" . tuareg-mode))
@@ -82,8 +82,8 @@ Run an OCaml toplevel process.  I/O via buffer `*ocaml-toplevel*'.
 
 ;;;***
 
-;;;### (autoloads nil nil ("tuareg-light.el" "tuareg-mly.el" "tuareg_indent.el")
-;;;;;;  (22359 21031 494316 93000))
+;;;### (autoloads nil nil ("dot-emacs.el" "tuareg-light.el" "tuareg_indent.el")
+;;;;;;  (22845 33659 181725 879000))
 
 ;;;***
 

--- a/tuareg.el
+++ b/tuareg.el
@@ -3068,7 +3068,9 @@ It is assumed that the range `start'-`end' delimit valid OCaml phrases."
   (save-excursion (tuareg-run-process-if-needed))
   (comint-preinput-scroll-to-bottom)
   (let* ((phrases (buffer-substring-no-properties start end))
-         (phrases-colon (concat phrases ";;")))
+         (phrases-colon (if (string-match-p ";;[ \t\n]*\\'" phrases)
+                            (replace-regexp-in-string "[ \t\n]*\\'" "" phrases)
+                          (concat phrases ";;"))))
     (if (string= phrases "")
         (message "Cannot send empty commands to OCaml toplevel!")
       (with-current-buffer tuareg-interactive-buffer-name


### PR DESCRIPTION
Hi,

I've noticed a small bug regarding the automatic addition of ;; and I'd like to propose a patch for that:

### Minimal test file
```ocaml
print_endline "Start";;
print_endline "End";;
```

### My configuration
- GNU/Linux Debian 8
- GNU Emacs 24.4.1
- OCaml [4.01.0](https://packages.debian.org/jessie/ocaml)
- `master` version of tuareg-mode (79bca7dc9254da190d821b504da4946df8c3d548)

### Steps to reproduce
`C-c C-b`

### Actual result
Buffer **\*ocaml-toplevel\***:
```ocaml
        OCaml version 4.01.0

print_endline "Start";;
print_endline "End";;
;;
# Start
- : unit = ()
# End
- : unit = ()
# Characters 0-2:
  ;;
  ^^
Error: Syntax error
# 
```

### Expected result
Avoid triggering a syntax error in this case.

### Implemented patch
If the phrases to be sent to the toplevel already end with ;; (and whitespace), the ;; is kept (and the string trimmed).

(I didn't know whether I had to commit the changes regarding tuareg-site-file.el - generated  by make - so I put it in a separated commit; tell me if you prefer that I remove this commit.)

Kind regards, Erik