### PR TITLE
Do not provide caml in tuareg.el

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -3553,8 +3553,4 @@ for a quick jump via the definitions menu."
 ;; Load it after providing `tuareg' to avoid circular dependencies.
 (if t (require 'tuareg_indent))         ;Don't load during compilation.
 
-;; For compatibility with caml support modes
-;; you may also link caml.el to tuareg.el
-(provide 'caml)
-
 ;;; tuareg.el ends here


### PR DESCRIPTION
```
The feature `caml' was provided "for compatibility with caml support
modes", i.e. so that such extensions would continue to function even
if their authors did not adjust them for tuareg.el.

However `tuareg.el' has evolved since then, for example many symbols
which were once named `caml-*' in `caml.el' are now prefixed with
`tuareg-*' instead.  Therefore a `caml' extension which has not been
adjusted by now and (among other things) still expects symbols with
the `caml-' prefix, will very likely fail to work when loading
`tuareg.el' but not `caml.el'.

It is better to fail with

  Cannot open load file: No such file or directory: caml

than to later get errors about undefined symbols.  This way a user can
immediately tell that some extension does not work because it requires
`caml' but `caml' is not available.  If some other library makes the
untrue claim that `caml' is available, then it becomes much harder to
figure out that this is in fact not the case.
```