### PR TITLE
Do not configure require-final-newline

### DIFF
--- a/tuareg-light.el
+++ b/tuareg-light.el
@@ -2364,8 +2364,6 @@ Short cuts for interactions with the toplevel:
   (setq paragraph-start (concat "^[ \t]*$\\|\\*)$\\|" page-delimiter))
   (make-local-variable 'paragraph-separate)
   (setq paragraph-separate paragraph-start)
-  (make-local-variable 'require-final-newline)
-  (setq require-final-newline t)
   (make-local-variable 'comment-start)
   (setq comment-start "(* ")
   (make-local-variable 'comment-end)

--- a/tuareg.el
+++ b/tuareg.el
@@ -2474,7 +2474,6 @@ Short cuts for interactions with the toplevel:
     (set (make-local-variable 'paragraph-start)
 	 (concat "^[ \t]*$\\|\\*)$\\|" page-delimiter))
     (set (make-local-variable 'paragraph-separate) paragraph-start)
-    (set (make-local-variable 'require-final-newline) t)
     (set (make-local-variable 'comment-start) "(* ")
     (set (make-local-variable 'comment-end) " *)")
     (set (make-local-variable 'comment-start-skip) "(\\*+[ \t]*")


### PR DESCRIPTION
Source files do not require a final newline. Thus, require-final-newline is a
personal setting and should not be configured in the major mode. Setting it
here will also negatively impact helpers like ethan-wspace.