### PR TITLE
Install tuareg-jbuild & tuareg-opam modes

### DIFF
--- a/tuareg.install
+++ b/tuareg.install
@@ -2,8 +2,11 @@ share_root: [
   "tuareg.el" {"emacs/site-lisp/tuareg.el"}
   "ocamldebug.el" {"emacs/site-lisp/ocamldebug.el"}
   "tuareg-site-file.el" {"emacs/site-lisp/tuareg-site-file.el"}
+  "tuareg-jbuild.el" {"emacs/site-lisp/tuareg-jbuild.el"}
+  "tuareg-opam.el" {"emacs/site-lisp/tuareg-opam.el"}
   "?tuareg.elc" {"emacs/site-lisp/tuareg.elc"}
-  "?tuareg_indent.elc" {"emacs/site-lisp/tuareg_indent.elc"}
   "?ocamldebug.elc" {"emacs/site-lisp/ocamldebug.elc"}
   "?tuareg-site-file.elc" {"emacs/site-lisp/tuareg-site-file.elc"}
+  "?tuareg-jbuild.elc" {"emacs/site-lisp/tuareg-jbuild.elc"}
+  "?tuareg-opam.elc" {"emacs/site-lisp/tuareg-opam.elc"}
 ]


### PR DESCRIPTION
Tuareg 2.1.0 introduces the ```tuareg-jbuild``` and ```tuareg-opam``` modes but both are not installed.
This PR also removes ```tuareg_indent.elc``` which is not referenced anywhere-else.
Also, I'm not sure if ```dot-emacs.el``` and ```tuareg-light.el``` were to be installed. Let me know if I should change this.