### PR TITLE
Fix tuareg-shell-command-to-string

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -2857,10 +2857,10 @@ error message as a string)."
   (let* ((return-value 0)
          (return-string
           (with-output-to-string
-	    (with-current-buffer standard-output
-	      (setq return-value
-		    (process-file shell-file-name nil t nil
-                                  shell-command-switch command))))))
+            (with-current-buffer standard-output
+              (setq return-value
+                    (process-file shell-file-name nil '(t nil)
+                                  nil shell-command-switch command))))))
     (if (= return-value 0) return-string nil)))
 
 (defun tuareg-opam-config-env (&optional switch)


### PR DESCRIPTION
The old argument list did not correctly ignore the stderr of the command. To reproduce, update to the latest opam 2.0 and see how it spits out warnings that aren't correctly ignored.

https://emacs.stackexchange.com/questions/21422/how-to-discard-stderr-when-running-a-shell-function

I'm not sure why my emacs indents the code differently, but it seems to make more sense? In particular, a nested sexp will always be to "the right" of its parent. In any case, feel free to re-indent when cherry-picking.