### PR TITLE
Allow bare underscore as a typevar

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -801,7 +801,7 @@ for the interactive mode."
                   "\\(?: *\\. *" extended-module-name "\\)*"))
          (modtype-path (concat "\\(?:" extended-module-path "\\.\\)*" id))
          (typevar "'[A-Za-z_][A-Za-z0-9_']*\\>")
-         (typeparam (concat "[+-]?" typevar))
+         (typeparam (concat "\\(?:[+-]?" typevar "\\|_\\)"))
          (typeparams (concat "\\(?:" typeparam "\\|( *"
                              typeparam " *\\(?:, *" typeparam " *\\)*)\\)"))
          (typedef (concat "\\(?:" typeparams " *\\)?" lid))


### PR DESCRIPTION
This introduces a slight regression because `typeparam` shouldn't allow `+_` or `-_`, but I suspect that's rare enough to be acceptable?