### PR TITLE
Update the modeline if there's a corresponding foo.mli file

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -249,6 +249,19 @@ See `ff-other-file-alist'."
   :group 'tuareg
   :type '(repeat (list regexp (choice (repeat string) function))))
 
+(defun tuareg--other-file (path)
+  "Given a PATH \"foo.ml\", return \"foo.mli\" if it exists.
+Return nil otherwise."
+  (when path
+    (let* ((ext (file-name-extension path))
+           (path-no-ext (file-name-sans-extension path))
+           (matching-exts
+            (cadr (assoc (format "\\.%s\\'" ext) tuareg-other-file-alist)))
+           (matching-paths
+            (mapcar (lambda (ext) (concat path-no-ext ext))
+                    matching-exts))
+           (paths (cl-remove-if-not #'file-exists-p matching-paths)))
+      (car paths))))
 
 (defcustom tuareg-interactive-scroll-to-bottom-on-output nil
   "*Controls when to scroll to the bottom of the interactive buffer
@@ -2811,6 +2824,12 @@ Short cuts for the Tuareg mode:
 Short cuts for interactions with the REPL:
 \\{tuareg-interactive-mode-map}"
 
+  (setq mode-name
+        '(:eval
+          (let ((other-file (tuareg--other-file (buffer-file-name))))
+            (if other-file
+                (format "Tuareg[+%s]" (file-name-extension other-file))
+              "Tuareg"))))
   (unless (tuareg--switch-outside-build)
     ;; Initialize the Tuareg menu
     (tuareg-build-menu)


### PR DESCRIPTION
If we're editing a foo.ml file, it's very useful to know if foo.mli
exists. Update the mode line to say "Tuareg[+mli]" to make it more
visible to the user.

Fixes #197