### PR TITLE
Unbind backspace to fix electric-pair-mode

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -1339,7 +1339,6 @@ Run only once."
     (define-key map "\C-c\C-k" 'tuareg-kill-ocaml)
     (define-key map "\C-c\C-n" 'tuareg-next-phrase)
     (define-key map "\C-c\C-p" 'tuareg-previous-phrase)
-    (define-key map [(backspace)] 'backward-delete-char-untabify)
     (define-key map [(control c) (home)]
       'tuareg-move-inside-module-or-class-opening)
     (define-key map "\C-c`" 'tuareg-interactive-next-error-source)


### PR DESCRIPTION
Currently, `electric-minor-mode` won't delete adjacent pairs. This is because tuareg-mode overrides backspace, that `electric-pair-mode-map` binds to `electric-pair-delete-pair`. 

Removing the `backward-delete-char-untabify` binding fixes this. I'm not sure if there was a reason for this, just that it was added over 10 years ago.