### PR TITLE
Make beginning-of-defun (C-M-a) repeatable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 script:
   - emacs --version
   - make elc
+  - make check-ert
   - make indent-test
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,11 @@ uninstall :
 .PHONY: refresh
 refresh:
 
-check : sample.ml.test
+check : sample.ml.test check-ert
+
+.PHONY: check-ert
+check-ert:
+	$(EMACS) -batch -Q -L . -l tuareg-tests -f ert-run-tests-batch-and-exit
 
 %.test: % $(ELC) refresh
 	@echo ====Indent $*====

--- a/tuareg-tests.el
+++ b/tuareg-tests.el
@@ -1,0 +1,80 @@
+;;; tests for tuareg.el                       -*- lexical-binding: t -*-
+
+(require 'tuareg)
+(require 'ert)
+
+(ert-deftest tuareg-beginning-of-defun ()
+  ;; Check that `beginning-of-defun' works as expected: move backwards
+  ;; to the beginning of the current top-level definition (defun), or
+  ;; the previous one if already at the beginning; return t if one was
+  ;; found, nil if none.
+  (with-temp-buffer
+    (tuareg-mode)
+    (let (p1 p2 p3 p4)
+      (insert "(* first line *)\n\n")
+      (setq p1 (point))
+      (insert "type ty =\n"
+              "  | Goo\n"
+              "  | Baa of int\n\n")
+      (setq p2 (point))
+      (insert "let a = ho hum\n"
+              ";;\n\n")
+      (setq p3 (point))
+      (insert "let g u =\n"
+              "  while mo ma do\n"
+              "    we wo;\n")
+      (setq p4 (point))
+      (insert "    ze zo\n"
+              "  done\n")
+
+      ;; Check without argument.
+      (goto-char p4)
+      (should (equal (beginning-of-defun) t))
+      (should (equal (point) p3))
+      (should (equal (beginning-of-defun) t))
+      (should (equal (point) p2))
+      (should (equal (beginning-of-defun) t))
+      (should (equal (point) p1))
+      (should (equal (beginning-of-defun) nil))
+      (should (equal (point) (point-min)))
+
+      ;; Check with positive argument.
+      (goto-char p4)
+      (should (equal (beginning-of-defun 1) t))
+      (should (equal (point) p3))
+      (goto-char p4)
+      (should (equal (beginning-of-defun 2) t))
+      (should (equal (point) p2))
+      (goto-char p4)
+      (should (equal (beginning-of-defun 3) t))
+      (should (equal (point) p1))
+      (goto-char p4)
+      (should (equal (beginning-of-defun 4) nil))
+      (should (equal (point) (point-min)))
+
+      ;; Check with negative argument.
+      (goto-char (point-min))
+      (should (equal (beginning-of-defun -1) t))
+      (should (equal (point) p1))
+      (should (equal (beginning-of-defun -1) t))
+      (should (equal (point) p2))
+      (should (equal (beginning-of-defun -1) t))
+      (should (equal (point) p3))
+      (should (equal (beginning-of-defun -1) nil))
+      (should (equal (point) (point-max)))
+
+      (goto-char (point-min))
+      (should (equal (beginning-of-defun -2) t))
+      (should (equal (point) p2))
+      (goto-char (point-min))
+      (should (equal (beginning-of-defun -3) t))
+      (should (equal (point) p3))
+      (goto-char (point-min))
+      (should (equal (beginning-of-defun -4) nil))
+      (should (equal (point) (point-max)))
+
+      ;; We don't test with a zero argument as the behaviour for that
+      ;; case does not seem to be very well-defined.
+      )))
+
+(provide 'tuareg-tests)


### PR DESCRIPTION
Ensure that `tuareg-beginning-of-defun` right at the beginning of a
defun moves point to the beginning of the previous defun rather than
being a no-op (issue #236). Also make the return value is correct for
a `beginning-of-defun-function`, as well as the semantics for negative
arguments.

Add tests, which are run automatically as part of Travis CI, or
manually by `make check-ert` or M-x ert.