### PR TITLE
Use opam var/env/exec instead of opam config x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ELS = $(SOURCES) tuareg-site-file.el
 ELC = $(ELS:.el=.elc)
 
 INSTALL_FILES = $(ELS) $(ELC)
-INSTALL_DIR ?= $(shell opam config var share)/emacs/site-lisp
+INSTALL_DIR ?= $(shell opam var share)/emacs/site-lisp
 
 DIST_FILES += $(ELS) Makefile README.md tuareg.install
 

--- a/tuareg-opam.el
+++ b/tuareg-opam.el
@@ -329,7 +329,7 @@ form (n v) where n is the name of the environment variable and v
 its value (both being strings).  If opam is not found or the
 switch is not installed, `nil' is returned."
   (let* ((switch (if switch (concat " --switch " switch)))
-	 (get-env (concat tuareg-opam " config env --sexp" switch))
+	 (get-env (concat tuareg-opam " env --sexp" switch))
 	 (opam-env (tuareg--shell-command-to-string get-env)))
     (if opam-env
 	(car (read-from-string opam-env)))))

--- a/tuareg.el
+++ b/tuareg.el
@@ -3118,7 +3118,7 @@ lines? \\([0-9]+\\)-?\\([0-9]+\\)?\
 (require 'tuareg-opam)
 (when (and tuareg-opam-insinuate tuareg-opam)
   (setq tuareg-interactive-program
-        (concat tuareg-opam " config exec -- ocaml"))
+        (concat tuareg-opam " exec -- ocaml"))
 
   (advice-add 'compile :before #'tuareg--compile-opam)
 


### PR DESCRIPTION
They are compatible 2.0 & 2.1+
cf. ocaml/opam#4503