### PR TITLE
Parse `class type` correctly (#239)

### DIFF
--- a/indent-test.ml
+++ b/indent-test.ml
@@ -852,9 +852,36 @@ let () =
       >>= fun () -> step2)
 
 class c (a : b) =
-object
+  object
+    inherit d
+    method m = 1
+  end
+
+class c (a : b) =
+  object(self)
+    inherit d
+    method m = 1
+  end
+
+class c (a : b) = object
   inherit d
   method m = 1
+end
+
+class c (a : b) = object(self)
+  inherit d
+  method m = 1
+end
+
+class type restricted_point_type =
+  object
+    method get_x : int
+    method bump : unit
+  end
+
+class type restricted_point_type = object
+  method get_x : int
+  method bump : unit
 end
 
 let f = {

--- a/tuareg-tests.el
+++ b/tuareg-tests.el
@@ -342,4 +342,23 @@ Returns the value of the last FORM."
                     (list p3 (1- p4) (1- p4))))
      )))
 
+(ert-deftest tuareg-class-type ()
+  (with-temp-buffer
+    (tuareg-mode)
+    (tuareg--lets
+     (insert "class type my_class_type =\n"
+             "  object\n"
+             "    method meth_1 : int\n"
+             "    method meth_2 : unit\n"
+             "  end;;\n")
+     (let p1 (point))
+
+     (goto-char (point-min))
+     (end-of-defun)
+     (should (equal (point) p1))
+     (beginning-of-defun)
+     (should (equal (point) (point-min)))
+     (should (equal (tuareg-discover-phrase (point-min))
+                    (list (point-min) (1- p1) (1- p1)))))))
+
 (provide 'tuareg-tests)

--- a/tuareg.el
+++ b/tuareg.el
@@ -2221,7 +2221,7 @@ Return values can be
    ;; An important role of this first condition is to call smie-indent-virtual
    ;; so that we get called back to compute the (virtual) indentation of
    ;; "object", thus making sure we get called back to apply the second rule.
-   ((and (member token '("inherit" "val" "method" "constraint"))
+   ((and (member token '("inherit" "val" "method" "constraint" "initializer"))
          (smie-rule-parent-p "object"))
     (save-excursion
       (forward-word 1)
@@ -2229,7 +2229,8 @@ Return values can be
       (let ((col (smie-indent-virtual)))
         `(column . ,(+ tuareg-default-indent col)))))
    ;; For "class foo = object(type)...end", align object...end with class.
-   ((and (equal token "object") (smie-rule-parent-p "class"))
+   ((and (equal token "object") (smie-rule-parent-p "class")
+         (not (smie-rule-bolp)))
     (smie-rule-parent))))
 
 (defun tuareg-smie--if-then-hack (token)

--- a/tuareg.el
+++ b/tuareg.el
@@ -1476,7 +1476,7 @@ For use on `electric-indent-functions'."
             (def-in-exp (defs "in" exp))
             (def (var "d=" exp) (id "d=" datatype) (id "d=" module))
             (idtype (id ":" type))
-            (var (id) ("m-type" var) ("d-type" var) ("rec" var)
+            (var (id) ("m-type" var) ("d-type" var) ("c-type" var) ("rec" var)
                  ("private" var) (idtype)
                  ("l-module" var) ("l-class" var))
             (exception (id "of" type))
@@ -1932,12 +1932,13 @@ Return values can be
                         (tuareg-smie--label-colon-p))))
           (if (member nearest '("with" "|" "fun" "function" "functor"))
               tok "t->"))))
-     ;; Handle "module type", mod-constraint's "with/and type" and
-     ;; polymorphic syntax.
+     ;; Handle "module type", "class type", mod-constraint's "with/and type"
+     ;; and polymorphic syntax.
      ((equal tok "type")
       (save-excursion
         (let ((prev (tuareg-smie--backward-token)))
           (cond ((equal prev "module") "m-type")
+                ((equal prev "class") "c-type")
                 ((member prev '("and" "with")) "w-type")
                 ((equal prev ":") "d-type"); ": type a. ..."
                 (t tok)))))


### PR DESCRIPTION
Lex "type" after "class" as "c-type", in analogy with "m-type".