### PR TITLE
Modernise and extend compilation error regexp

### DIFF
--- a/compilation.txt
+++ b/compilation.txt
@@ -112,3 +112,11 @@ Warning 3: This expression has type M/2.t but an expression was expected of type
          Definition of module M/1
        File "main.ml", line 7, characters 0-32:
          Definition of module M/2
+
+
+* Since OCaml 4.12, warnings come with mnemonics.
+
+File "moo.ml", line 6, characters 6-10:
+6 |   let fish = 13 in
+          ^^^^
+Warning 26 [unused-var]: unused variable fish.

--- a/compilation.txt
+++ b/compilation.txt
@@ -120,3 +120,31 @@ File "moo.ml", line 6, characters 6-10:
 6 |   let fish = 13 in
           ^^^^
 Warning 26 [unused-var]: unused variable fish.
+
+
+* Backtrace messages
+
+Before 4.11:
+
+OCAMLRUNPARAM=b ./bad
+Fatal error: exception Bad.Disaster("oh no!")
+Raised at file "bad.ml", line 5, characters 4-22
+Called from file "bad.ml" (inlined), line 9, characters 2-5
+Called from file "bad.ml", line 12, characters 8-18
+
+4.11 and later:
+
+OCAMLRUNPARAM=b ./bad
+Fatal error: exception Bad.Disaster("oh no!")
+Raised at Bad.f in file "bad.ml", line 5, characters 4-22
+Called from Bad.g in file "bad.ml" (inlined), line 9, characters 2-5
+Called from Bad in file "bad.ml", line 12, characters 8-18
+
+OCAMLRUNPARAM=b ./bad
+Fatal error: exception Sys_error("non.existing.file: No such file or directory")
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 399, characters 28-54
+Called from Bad.h in file "bad.ml", line 7, characters 13-40
+Called from Bad.f in file "bad.ml", line 13, characters 4-7
+Re-raised at Bad.f in file "bad.ml", line 14, characters 12-19
+Called from Bad.g in file "bad.ml", line 17, characters 2-5
+Called from Bad in file "bad.ml", line 20, characters 8-18

--- a/tuareg-tests.el
+++ b/tuareg-tests.el
@@ -396,17 +396,17 @@ Returns the value of the last FORM."
   '((("File \"file.ml\", line 4, characters 6-7:\n"
       "Error: This expression has type int\n"
       "This is not a function; it cannot be applied.\n")
-     ((1 error "file.ml" 4 4 6 7)))
+     ((1 error "file.ml" 4 4 6 6)))
     (("File \"file.ml\", line 3, characters 6-7:\n"
       "Warning 26: unused variable y.\n")
-     ((1 warning "file.ml" 3 3 6 7)))
+     ((1 warning "file.ml" 3 3 6 6)))
 
     (("File \"helloworld.ml\", line 2, characters 36-64:\n"
       "2 | module rec A: sig type t += A end = struct type t += A = B.A end\n"
       "                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
       "Error: Cannot safely evaluate the definition of the following cycle\n"
       "       of recursively-defined modules: A -> B -> A.\n")
-     ((1 error "helloworld.ml" 2 2 36 64)))
+     ((1 error "helloworld.ml" 2 2 36 63)))
     (("File \"helloworld.ml\", lines 4-7, characters 6-3:\n"
       "4 | ......struct\n"
       "5 |   module F(X:sig end) = struct end\n"
@@ -414,7 +414,7 @@ Returns the value of the last FORM."
       "7 | end\n"
       "Error: Cannot safely evaluate the definition of the following cycle\n"
       "       of recursively-defined modules: A -> B -> A.\n")
-     ((1 error "helloworld.ml" 4 7 6 3)))
+     ((1 error "helloworld.ml" 4 7 6 2)))
     (("File \"robustmatch.ml\", lines 33-37, characters 6-23:\n"
       " 9 | ......match t1, t2, x with\n"
       "10 |       | AB, AB, A -> ()\n"
@@ -424,7 +424,7 @@ Returns the value of the last FORM."
       "Warning 8: this pattern-matching is not exhaustive.\n"
       "Here is an example of a case that is not matched:\n"
       "(AB, MAB, A)\n")
-     ((1 warning "robustmatch.ml" 33 37 6 23)))
+     ((1 warning "robustmatch.ml" 33 37 6 22)))
     (("File \"robustmatch.ml\", lines 33-37, characters 6-23:\n"
       " 9 | ......match t1, t2, x with\n"
       "10 |       | AB, AB, A -> ()\n"
@@ -434,7 +434,7 @@ Returns the value of the last FORM."
       "Warning 8 [partial-match]: this pattern-matching is not exhaustive.\n"
       "Here is an example of a case that is not matched:\n"
       "(AB, MAB, A)\n")
-     ((1 warning "robustmatch.ml" 33 37 6 23)))
+     ((1 warning "robustmatch.ml" 33 37 6 22)))
     (("File \"main.ml\", line 13, characters 34-35:\n"
       "13 |   let f : M.t -> M.t = fun M.C -> y\n"
       "                                       ^\n"
@@ -444,32 +444,32 @@ Returns the value of the last FORM."
       "         Definition of module M/1\n"
       "       File \"main.ml\", line 7, characters 0-32:\n"
       "         Definition of module M/2\n")
-     ((1 error "main.ml" 13 13 34 35)
-      (225 error "main.ml" 10 10 2 41)
-      (308 error "main.ml" 7 7 0 32)))
+     ((1 error "main.ml" 13 13 34 34)
+      (225 error "main.ml" 10 10 2 40)
+      (308 error "main.ml" 7 7 0 31)))
     (("Fatal error: exception Bad.Disaster(\"oh no!\")\n"
       "Raised at file \"bad.ml\", line 5, characters 4-22\n"
       "Called from file \"worse.ml\" (inlined), line 9, characters 2-5\n"
       "Called from file \"worst.ml\", line 12, characters 8-18\n")
-     ((47 error "bad.ml" 5 5 4 22)
-      (96 error "worse.ml" 9 9 2 5)
-      (158 error "worst.ml" 12 12 8 18)))
+     ((47 error "bad.ml" 5 5 4 21)
+      (96 error "worse.ml" 9 9 2 4)
+      (158 error "worst.ml" 12 12 8 17)))
     (("Fatal error: exception Bad.Disaster(\"oh no!\")\n"
       "Raised at Bad.f in file \"bad.ml\", line 5, characters 4-22\n"
       "Called from Bad.g in file \"worse.ml\" (inlined), line 9, characters 2-5\n"
       "Called from Bad in file \"worst.ml\", line 12, characters 8-18\n")
-     ((47 error "bad.ml" 5 5 4 22)
-      (105 error "worse.ml" 9 9 2 5)
-      (176 error "worst.ml" 12 12 8 18)))
+     ((47 error "bad.ml" 5 5 4 21)
+      (105 error "worse.ml" 9 9 2 4)
+      (176 error "worst.ml" 12 12 8 17)))
     (("Fatal error: exception Hell\n"
       "Raised by primitive operation at Murky.depths in file \"inferno.ml\", line 399, characters 28-54\n"
       "Called from Nasty.f in file \"nasty.ml\", line 7, characters 13-40\n"
       "Re-raised at Smelly.f in file \"smelly.ml\", line 14, characters 12-19\n"
       "Called from Rubbish.g in file \"rubbish.ml\", line 17, characters 2-5\n")
-     ((29 error "inferno.ml" 399 399 28 54)
-      (124 error "nasty.ml" 7 7 13 40)
-      (189 error "smelly.ml" 14 14 12 19)
-      (258 error "rubbish.ml" 17 17 2 5))))
+     ((29 error "inferno.ml" 399 399 28 53)
+      (124 error "nasty.ml" 7 7 13 39)
+      (189 error "smelly.ml" 14 14 12 18)
+      (258 error "rubbish.ml" 17 17 2 4))))
   "Compilation message test data.
 Each element is (STRINGS ERRORS) where
 

--- a/tuareg.el
+++ b/tuareg.el
@@ -3158,12 +3158,10 @@ Short cuts for interactions with the REPL:
        (backref 2)
        ", line" (? "s") " "
        (group (+ (in "0-9")))               ; 4: LINE-START
-       (? "-")
-       (? (group (+ (in "0-9"))))           ; 5; LINE-END
+       (? "-" (group (+ (in "0-9"))))       ; 5; LINE-END
        (? ", character" (? "s") " "
           (group (+ (in "0-9")))            ; 6: COL-START
-          (? "-")
-          (? (group (+ (in "0-9")))))       ; 7: COL-END
+          (? "-" (group (+ (in "0-9")))))   ; 7: COL-END
        ":")
       (? "\n"
          (* (in "\t "))

--- a/tuareg.el
+++ b/tuareg.el
@@ -3174,8 +3174,9 @@ Short cuts for interactions with the REPL:
             "\n"
             (* (in "\t ")))
          (group "Warning"                   ; 8: WARNING
-                (? " " (+ (in "0-9"))))
-         ":"))
+                (? " " (+ (in "0-9")))
+                (? " [" (+ (in "a-z0-9-")) "]")
+                ":")))
   "Regular expression matching the error messages produced by ocamlc/ocamlopt.")
 
 (when (boundp 'compilation-error-regexp-alist-alist)

--- a/tuareg.el
+++ b/tuareg.el
@@ -3149,11 +3149,33 @@ Short cuts for interactions with the REPL:
 ;; the language is not English.  Hence we add a regexp.
 
 (defconst tuareg--error-regexp
-  "^ *\\(File \\(\"?\\)\\([^,\" \n\t<>]+\\)\\2, \
-lines? \\([0-9]+\\)-?\\([0-9]+\\)?\
-\\(?:, characters? \\([0-9]+\\)-?\\([0-9]+\\)?\\)?:\\)\
-\\(?:\n[ \t]*\\(?:\\(?:[0-9]+ | .*\\|\\^+\\)\n[ \t]*\\)*\
-\\(Warning\\(?: [0-9]+\\)?\\):\\)?"
+  (rx bol
+      (* " ")
+      (group                                ; 1: HIGHLIGHT
+       "File "
+       (group (? "\""))                     ; 2
+       (group (+ (not (in "\t\n \",<>"))))  ; 3: FILE
+       (backref 2)
+       ", line" (? "s") " "
+       (group (+ (in "0-9")))               ; 4: LINE-START
+       (? "-")
+       (? (group (+ (in "0-9"))))           ; 5; LINE-END
+       (? ", character" (? "s") " "
+          (group (+ (in "0-9")))            ; 6: COL-START
+          (? "-")
+          (? (group (+ (in "0-9")))))       ; 7: COL-END
+       ":")
+      (? "\n"
+         (* (in "\t "))
+         (* (or (seq (+ (in "0-9"))
+                     " | "
+                     (* nonl))
+                (+ "^"))
+            "\n"
+            (* (in "\t ")))
+         (group "Warning"                   ; 8: WARNING
+                (? " " (+ (in "0-9"))))
+         ":"))
   "Regular expression matching the error messages produced by ocamlc/ocamlopt.")
 
 (when (boundp 'compilation-error-regexp-alist-alist)

--- a/tuareg.el
+++ b/tuareg.el
@@ -3179,11 +3179,15 @@ Short cuts for interactions with the REPL:
   "Regular expression matching the error messages produced by ocamlc/ocamlopt.")
 
 (when (boundp 'compilation-error-regexp-alist-alist)
+  (setq compilation-error-regexp-alist-alist
+        (assq-delete-all 'ocaml compilation-error-regexp-alist-alist))
   (push `(ocaml ,tuareg--error-regexp 3 (4 . 5) (6 . 7) (8) 1
                 (8 font-lock-function-name-face))
         compilation-error-regexp-alist-alist))
 
 (when (boundp 'compilation-error-regexp-alist)
+  (setq compilation-error-regexp-alist
+        (delq 'ocaml compilation-error-regexp-alist))
   (push 'ocaml compilation-error-regexp-alist)
 
   (eval-after-load 'caml

--- a/tuareg.el
+++ b/tuareg.el
@@ -3152,17 +3152,25 @@ Short cuts for interactions with the REPL:
   (rx bol
       (* " ")
       (group                                ; 1: HIGHLIGHT
-       "File "
+       (or "File "
+           ;; Exception backtrace.
+           (seq
+            (or "Raised at" "Re-raised at" "Raised by primitive operation at"
+                "Called from")
+            (* nonl)            ; OCaml ≥4.11: " FUNCTION in"
+            " file "))
        (group (? "\""))                     ; 2
        (group (+ (not (in "\t\n \",<>"))))  ; 3: FILE
        (backref 2)
+       (? " (inlined)")
        ", line" (? "s") " "
        (group (+ (in "0-9")))               ; 4: LINE-START
        (? "-" (group (+ (in "0-9"))))       ; 5; LINE-END
        (? ", character" (? "s") " "
           (group (+ (in "0-9")))            ; 6: COL-START
           (? "-" (group (+ (in "0-9")))))   ; 7: COL-END
-       ":")
+       ;; Colon not present in backtraces.
+       (? ":"))
       (? "\n"
          (* (in "\t "))
          (* (or (seq (+ (in "0-9"))
@@ -3175,7 +3183,8 @@ Short cuts for interactions with the REPL:
                 (? " " (+ (in "0-9")))
                 (? " [" (+ (in "a-z0-9-")) "]")
                 ":")))
-  "Regular expression matching the error messages produced by ocamlc/ocamlopt.")
+  "Regular expression matching the error messages produced by ocamlc/ocamlopt.
+Also matches source references in exception backtraces.")
 
 (when (boundp 'compilation-error-regexp-alist-alist)
   (setq compilation-error-regexp-alist-alist

--- a/tuareg.el
+++ b/tuareg.el
@@ -3186,10 +3186,19 @@ Short cuts for interactions with the REPL:
   "Regular expression matching the error messages produced by ocamlc/ocamlopt.
 Also matches source references in exception backtraces.")
 
+(defun tuareg--end-column ()
+  "Return the end-column number in a parsed OCaml message.
+OCaml uses exclusive end-columns but Emacs wants them to be inclusive."
+  (and (match-beginning 7)
+       (+ (string-to-number (match-string 7))
+          ;; Prior to Emacs 28, the end-column function value was incorrectly
+          ;; off by one.
+          (if (>= emacs-major-version 28) -1 0))))
+
 (when (boundp 'compilation-error-regexp-alist-alist)
   (setq compilation-error-regexp-alist-alist
         (assq-delete-all 'ocaml compilation-error-regexp-alist-alist))
-  (push `(ocaml ,tuareg--error-regexp 3 (4 . 5) (6 . 7) (8) 1
+  (push `(ocaml ,tuareg--error-regexp 3 (4 . 5) (6 . tuareg--end-column) (8) 1
                 (8 font-lock-function-name-face))
         compilation-error-regexp-alist-alist))
 


### PR DESCRIPTION
Make `tuareg--error-regexp` readable and fix a few deficiencies with respect to modern OCaml compiler versions.
Also extend it to handle source locations in exception backtraces.
