### PR TITLE
Fix indentation and paragraph-fill inside comments

### DIFF
--- a/indent-test.ml
+++ b/indent-test.ml
@@ -44,11 +44,14 @@ let qs1 = {| quoted string |}   (* (issue #24) *)
 let qs2 = {eof| other quoted string   |noteof}  |eof}
 
 (* ocp-indent does it as follows:
-let test1 = with_connection (fun conn ->
-    do_something conn x;
-    ...
-  )
-    toto
+
+   let test1 = with_connection (fun conn ->
+   ␣␣␣␣do_something conn x;
+   ␣␣␣␣...
+   ␣␣)
+   ␣␣␣␣toto
+
+   (space written as ␣ to avoid reindent smashing this comment)
  *)
 let test1 = with_connection (fun conn ->
                 do_something conn x;

--- a/tuareg-tests.el
+++ b/tuareg-tests.el
@@ -718,7 +718,7 @@ the original code."
                          "      beta\n"
                          "  \n"
                          "      gamma\n")))
-  ;; Indent to text after @-tags in doc comments.
+  ;; Indent text after @-tags in doc comments by 2 more spaces.
   (should (equal (tuareg-test--do-at-line
                   (concat "  (** alpha\n"
                           "        @param beta\n"
@@ -726,7 +726,7 @@ the original code."
                   2 #'indent-for-tab-command)
                  (concat "  (** alpha\n"
                          "        @param beta\n"
-                         "               gamma\n")))
+                         "          gamma\n")))
   ;; An @-tag starts a new paragraph.
   (should (equal (tuareg-test--do-at-line
                   (concat "  (** alpha\n"
@@ -799,7 +799,7 @@ the original code."
                           "      beta\n"
                           "       @param gamma delta epsilon\n"
                           "       @param zeta eta\n"
-                          "              theta iota\n")))
+                          "         theta iota\n")))
   )
 
 

--- a/tuareg.el
+++ b/tuareg.el
@@ -2920,11 +2920,10 @@ This function moves the point."
                (goto-char par-start)
                (let ((col
                       (if (and in-doc-comment
-                               (looking-at (rx "@" (+ (in "a-z")) symbol-end)))
-                          (progn
-                            ;; Indent after @tag. Is this excessive?
-                            (goto-char (match-end 0))
-                            (1+ (current-column)))
+                               (looking-at-p
+                                (rx "@" (+ (in "a-z")) symbol-end)))
+                          ;; Indent two spaces under @tag.
+                          (+ 2 (current-column))
                         (current-column))))
                  (make-string col ?\s)))))
         (fill-region-as-paragraph par-start par-end)))))
@@ -3175,8 +3174,8 @@ file outside _build? "))
                     (skip-chars-forward " \t")
                     (when (and in-doc-comment
                                (not tag-starts-line)
-                               (looking-at (rx "@" (+ (in "a-z")) " ")))
-                      (goto-char (match-end 0))))
+                               (looking-at-p (rx "@" (+ (in "a-z")) " ")))
+                      (forward-char 2)))
                   (current-column))))
            (indent-line-to indent-col)
            t))))


### PR DESCRIPTION
Inside comments, explicit indentation as well as the automatic
indentation with electric-indent-mode active (just pressing RET, in
Emacs 28) now use the indentation of the previous nonempty line, even
when that line is on the same line as the initial `(*`.

Filling paragraphs with M-q inside a comment now only fills a single
paragraph instead of the entire comment. On an empty line, the
preceding paragraph is used.

Inside doc comments, lines starting with @-tags (like `@param`) start
a paragraph, and subsequent lines are indented to the text after the
tag.

Fixes #213.