### PR TITLE
Fix `tuareg-interactive-error-range-regexp`

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -3683,15 +3683,16 @@ It is assumed that the range START-END delimit valid OCaml phrases."
 (defun tuareg-eval-region (start end)
   "Eval the current region in the OCaml REPL."
   (interactive "r")
+  ;; Use the smallest region containing the phrase(s) at either endpoint.
+  (dolist (pos (list start end))
+    (save-excursion
+      (goto-char pos)
+      (let ((phrase (tuareg-discover-phrase)))
+        (when phrase
+          (setq start (min start (car phrase)))
+          (setq end (max end (cadr phrase)))))))
   (setq tuareg-interactive-last-phrase-pos-in-source start)
-  (save-excursion
-    (goto-char start)
-    (tuareg-backward-beginning-of-defun)
-    (setq start (point))
-    (setq end (cdr (tuareg-region-of-defun end)))
-    (if end
-        (tuareg-interactive--send-region start end)
-      (message "The expression after the point is not well braced."))))
+  (tuareg-interactive--send-region start end))
 
 (define-obsolete-function-alias 'tuareg-narrow-to-phrase #'narrow-to-defun
   "Apr 10, 2019")

--- a/tuareg.el
+++ b/tuareg.el
@@ -3715,9 +3715,6 @@ If the region is active, evaluate all phrases intersecting the region."
                 (setq start (min start beg-phrase))
                 (setq end (max end end-phrase))))))))
      (t
-      ;; Move before the comment, if we are in one.
-      (let ((ppss (syntax-ppss)))
-        (if (nth 4 ppss) (goto-char (1- (nth 8 ppss)))))
       (let ((phrase (tuareg-discover-phrase)))
         (unless phrase
           (user-error "Expression after the point is not well braced"))

--- a/tuareg.el
+++ b/tuareg.el
@@ -3724,10 +3724,15 @@ If the region is active, evaluate all phrases intersecting the region."
         (setq start (car phrase))
         (setq end (cadr phrase)))))
     (tuareg-interactive--send-region start end)
-    (if (not tuareg-skip-after-eval-phrase)
-        (goto-char opoint)
-      (goto-char end)
-      (tuareg-skip-blank-and-comments))))
+    (if tuareg-skip-after-eval-phrase
+        (progn
+          (when (region-active-p)
+            ;; We are moving point and the user probably doesn't
+            ;; expect the region to be affected.
+            (deactivate-mark))
+          (goto-char end)
+          (tuareg-skip-blank-and-comments))
+      (goto-char opoint))))
 
 (defun tuareg-eval-buffer ()
   "Send the buffer to the Tuareg Interactive process."


### PR DESCRIPTION
Update it to match error messages from recent OCaml versions, and fix related problems.

See #248, #273 and #231.