### PR TITLE
Prevent "Invalid search bound" error on long patterns

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -1348,6 +1348,7 @@ It must not be used outside fontification purposes."
            pos)
       (setq tuareg--pattern-matcher-limit nil)
       (while (and
+              (<= (point) limit)
               (setq pos (re-search-forward "[=({:]" limit t))
               (progn
                 (backward-char)
@@ -1387,6 +1388,7 @@ It must not be used outside fontification purposes."
            (limit (+ opoint 800))
            pos)
       (while (and
+              (<= (point) limit)
               (setq pos (re-search-forward "[-({]" limit t))
               (cond
                ((or (char-equal ?\( (char-before))


### PR DESCRIPTION
When `tuareg--pattern-pre-form-let` is invoked at the beginning of a let binding whose LHS is very long (> 800 characters), it can signal the following error:

    Invalid search bound (wrong side of point)

This happens when a balanced set of parentheses includes the limit position, so `forward-list` skips past it and thereby causes point to exceed limit.

Apply the same fix to `tuareg--pattern-pre-form-fun` by analogy. `tuareg--pattern-equal-matcher` is already correct.

Here's an example snippet where this error can happen:

```
let xxxx_xxxxxx
      (type value)
      ~(f :
          xxxx
        -> ( xxxxx * (xxxxx_xxxx, xxx_xxxxx) Xxxxxxxx_xxxxx.Xxxx_xx_xxxxxxx_xxxxx.x
           , (xxxxx_xxxx, xxx_xxxxx) Xxxxxx.x
           , xxxxx_xxxx )
             Xxxxxxx_xxxxxxxx_xxxxxx.Xx_xxx_xxxxxxxxxxx.x)
      ~(xxxx : Xxxx_xxxxxxx.Xxxxxx_xxxx.x)
      ~(xxxxxxxx : xxxxx Xxxxxxx.Xx_xxxxxxxxx.x)
      ~(xxxxxx_xxxxx : (xxxxx_xxxx, xxx_xxxxx) Xxxxxxxx_xxxxx.Xxxx_xx_xxxxxxx_xxxxx.xxxxxx)
      ~(xxxxxx_xxxxx : (xxxxx_xxxx, xxx_xxxxx) Xxxxxxxx_xxxxx.Xxxx_xx_xxxxxxx_xxxxx.xxxxxx)
      ~(xxxxxxxx_xxxxx : (xxxxx_xxxx, xxx_xxxxx) Xxxxxxxx_xxxxx.Xxxx_xx_xxxxxxx_xxxxx.x)
      ~(xxxxx_xxxxx : xxxxx -> xxxxx -> xxxx)
  : ( xxxxx * (xxxxx_xxxx, xxx_xxxxx) Xxxxxxxx_xxxxx.Xxxx_xx_xxxxxxx_xxxxx.x
    , (xxxxx_xxxx, xxx_xxxxx) Xxxxxx.x, xxxxx_xxxx )
      Xxxxxxx_xxxxxxxx_xxxxxx.Xx_xxx_xxxxxxxxxxx.x
  =
  xxxx
;;
```

Opening this file in tuareg-mode results in the following error in the `*Messages*` buffer:

```
Error during redisplay: (jit-lock-function 1) signaled (error "Invalid search bound (wrong side of point)")
```