### PR TITLE
feat: Add support for opam-switch-mode (>= 1.6)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+----------
+
+* Add support for [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode): enable the mode with <kbd>M-x opam-switch-mode</kbd> or add an automatic hook `(add-hook 'tuareg-mode-hook #'opam-switch-mode)`.
+
 3.0.1 2022-09-29
 ----------------
 

--- a/tuareg-opam.el
+++ b/tuareg-opam.el
@@ -348,7 +348,8 @@ issue an \"opam switch\" in a shell.  If this variable is set to
 t, Tuareg will try to use opam to set the right environment for
 `compile', `run-ocaml' and `merlin-mode' based on the current
 opam switch at the time the command is run (provided opam is
-found).  You may also use `tuareg-opam-update-env' to set the
+found).  You may also use `tuareg-opam-update-env', or the menus
+from the ELPA package `opam-switch-mode', to set the
 environment for another compiler from within emacs (without
 changing the opam switch).  Beware that setting it to t causes
 problems if you compile under tramp."
@@ -382,7 +383,11 @@ error message as a string)."
 
 ;;;###autoload
 (defun tuareg-opam-update-env (switch)
-  "Update the environment to follow current OPAM switch configuration."
+  "Update the environment to follow current OPAM switch configuration.
+
+You may also be interested in the ELPA package `opam-switch-mode' that
+provides a similar feature, along with a menu-bar and a mode-bar menu
+`\"OPSW\"'; see https://github.com/ProofGeneral/opam-switch-mode."
   (interactive
    (let* ((compl (tuareg-opam-installed-compilers))
           (current (tuareg-opam-current-compiler))

--- a/tuareg-opam.el
+++ b/tuareg-opam.el
@@ -351,8 +351,8 @@ opam switch at the time the command is run (provided opam is
 found).  You may also use `tuareg-opam-update-env', or the menus
 from the ELPA package `opam-switch-mode', to set the
 environment for another compiler from within emacs (without
-changing the opam switch).  Beware that setting it to t causes
-problems if you compile under tramp."
+affecting the OPAM switches outside of this Emacs session).
+Beware that setting it to t causes problems if you compile under tramp."
   :group 'tuareg :type 'boolean)
 
 (defun tuareg--shell-command-to-string (command)
@@ -385,23 +385,30 @@ error message as a string)."
 (defun tuareg-opam-update-env (switch)
   "Update the environment to follow current OPAM switch configuration.
 
-You may also be interested in the ELPA package `opam-switch-mode' that
-provides a similar feature, along with a menu-bar and a mode-bar menu
-`\"OPSW\"'; see https://github.com/ProofGeneral/opam-switch-mode."
+Delegate the task to `opam-switch-set-switch' if the minor mode
+`opam-switch-mode' (https://github.com/ProofGeneral/opam-switch-mode)
+is installed. This ELPA package also provides a menu-bar and a
+mode-bar menu `\"OPSW\"'."
   (interactive
    (let* ((compl (tuareg-opam-installed-compilers))
           (current (tuareg-opam-current-compiler))
           (default (if current current "current"))
           (prompt (format "opam switch (default: %s): " default)))
-     (list (completing-read prompt compl))))
-  (let* ((switch (if (string= switch "") nil switch))
-         (env (tuareg-opam-config-env switch)))
-    (if env
-        (dolist (v env)
-          (setenv (car v) (cadr v))
-          (when (string= (car v) "PATH")
-            (setq exec-path (split-string (cadr v) path-separator))))
-      (message "Switch %s does not exist (or opam not found)" switch))))
+     (if (fboundp 'opam-switch-set-switch)
+         '("Please use opam-switch-mode interactively")
+       (list (completing-read prompt compl)))))
+  (if (fboundp 'opam-switch-set-switch)
+      (if (called-interactively-p 'any)
+          (call-interactively #'opam-switch-set-switch)
+        (opam-switch-set-switch switch))
+    (let* ((switch (if (string= switch "") nil switch))
+           (env (tuareg-opam-config-env switch)))
+      (if env
+          (dolist (v env)
+            (setenv (car v) (cadr v))
+            (when (string= (car v) "PATH")
+              (setq exec-path (split-string (cadr v) path-separator))))
+        (message "Switch %s does not exist (or opam not found)" switch)))))
 
 ;; OPAM compilation
 (defun tuareg--compile-opam (&rest _)

--- a/tuareg.el
+++ b/tuareg.el
@@ -1,7 +1,7 @@
 ;;; tuareg.el --- OCaml mode  -*- coding: utf-8; lexical-binding:t -*-
 
 ;; Copyright (C) 1997-2006 Albert Cohen, all rights reserved.
-;; Copyright (C) 2011-2022 Free Software Foundation, Inc.
+;; Copyright (C) 2011-2023 Free Software Foundation, Inc.
 ;; Copyright (C) 2009-2010 Jane Street Holding, LLC.
 
 ;; Author: Albert Cohen <Albert.Cohen@inria.fr>
@@ -3935,6 +3935,36 @@ If the region is active, evaluate all phrases intersecting the region."
   (when (comint-check-proc tuareg-interactive-buffer-name)
     (with-current-buffer tuareg-interactive-buffer-name
       (comint-kill-subjob))))
+
+(defcustom tuareg-kill-ocaml-on-opam-switch t
+  "If t, kill the OCaml toplevel before the opam switch changes.
+If the user changes the opam switch using `opam-switch-set-switch'
+or an `\"OPSW\"' menu from `opam-switch-mode', this option asks to
+kill the OCaml toplevel process, so that the next eval command
+starts a new process, typically with a different OCaml version
+from a different opam switch.
+
+See https://github.com/ProofGeneral/opam-switch-mode
+
+Note: `opam-switch-mode' triggers automatic changes for `exec-path'
+and `process-environment', which are useful to find the `\"ocaml\"'
+binary and that of its subprocesses, in the ambient opam switch.
+
+`opam-switch-mode' 1.6+ is compatible with `tuareg-mode' whatever
+is the value of `tuareg-opam-insinuate' (albeit the default value
+nil is recommended as it omits the `\"opam exec --\"' wrapper)."
+  :type 'boolean)
+
+(defun tuareg--kill-ocaml-on-opam-switch ()
+  "Kill the OCaml toplevel before the opam switch changes.
+This function is for the `opam-switch-mode' hook
+`opam-switch-before-change-opam-switch-hook', which runs just
+before the user changes the opam switch through `opam-switch-mode'."
+  (when tuareg-kill-ocaml-on-opam-switch
+    (tuareg-kill-ocaml)))
+
+(add-hook 'opam-switch-before-change-opam-switch-hook
+          #'tuareg--kill-ocaml-on-opam-switch t)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                               Menu support

--- a/tuareg.el
+++ b/tuareg.el
@@ -3937,12 +3937,10 @@ If the region is active, evaluate all phrases intersecting the region."
       (comint-kill-subjob))))
 
 (defcustom tuareg-kill-ocaml-on-opam-switch t
-  "If t, kill the OCaml toplevel before the opam switch changes.
-If the user changes the opam switch using `opam-switch-set-switch'
-or an `\"OPSW\"' menu from `opam-switch-mode', this option asks to
-kill the OCaml toplevel process, so that the next eval command
-starts a new process, typically with a different OCaml version
-from a different opam switch.
+    "If t, kill Tuareg subprocesses when the OPAM switch changes.
+If the user changes the OPAM switch using `opam-switch-mode',
+this option asks to kill the subprocesses that are using the old
+switch.
 
 See https://github.com/ProofGeneral/opam-switch-mode
 
@@ -3950,9 +3948,8 @@ Note: `opam-switch-mode' triggers automatic changes for `exec-path'
 and `process-environment', which are useful to find the `\"ocaml\"'
 binary and that of its subprocesses, in the ambient opam switch.
 
-`opam-switch-mode' 1.6+ is compatible with `tuareg-mode' whatever
-is the value of `tuareg-opam-insinuate' (albeit the default value
-nil is recommended as it omits the `\"opam exec --\"' wrapper)."
+`opam-switch-mode' is compatible with `tuareg-mode' whatever is
+the value of `tuareg-opam-insinuate'."
   :type 'boolean)
 
 (defun tuareg--kill-ocaml-on-opam-switch ()


### PR DESCRIPTION
## Overall description

This PR adds support for `opam-switch-mode` (initially written by @hendriktews for [proof-general](https://proofgeneral.github.io) then as a separate ELPA package, further extended by @monnier and myself).

This minor mode is similar to tuareg's feature `M-x tuareg-opam-update-env` but it brings several additional features:

* (since version ≥ 1.4) it displays the currently chosen switch in the mode-line;
* it adds an "OPSW" menu-bar (also working in TTY) and an "OPSW" mode-bar menu, allowing to select a global opam switch or a local opam switch;
* it triggers the functions registered in opam-switch-mode's hook (typically, `tuareg-kill-ocaml` (and [likewise](https://github.com/ocaml/merlin/pull/1654) for `merlin-stop-server`));
* and finally it stores the initial environment (before the mode is enabled), providing a "reset" feature to backtrack to the initially chosen opam switch.

See the following screenshot of opam-switch-mode version 1.3 for a glimpse of the minor mode.

![2023-07-11_16-04-24_Screenshot_OPSW_menus](https://github.com/ocaml/merlin/assets/10367254/76d1c5dc-0e76-4f76-95a0-aa5314ba4440)

## Remarks

* This PR does NOT add opam-switch-mode as a dependency of tuareg: it is an optional, accompanying package (only useful for ocaml developers that rely on opam), and it is mostly language-agnostic (apart from using the opam tool !-)
* The [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode) package is available in MELPA, MELPA Stable, NonGNU-devel, [NonGNU](https://elpa.nongnu.org/nongnu/opam-switch-mode.html).
* ~~It requires the following setting: `(setq tuareg-opam-insinuate nil)`, but fortunately, this is the default value of the option.~~ **Edit:** this constraint is now relaxed.
* The only `Package-Requires:` of opam-switch-mode is `(emacs "25.1")`, which is compatible with Tuareg's one.

## Details of the commit

* Add option `tuareg-kill-ocaml-on-opam-switch` (default: t) and related function `(tuareg--kill-ocaml-on-opam-switch)` that kills the ocaml toplevel just before we change the opam switch using the OPSW menu-bar or the OPSW mode-bar from opam-switch-mode.