### PR TITLE
fix: tuareg: use #'; don't mark (tuareg-opam-update-env) as obsolete & docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ location of an identifier with <kbd>C-cC-l</kbd>, to go to the next
 (resp. previous) phrase with <kbd>C-cC-n</kbd>
 (resp. <kbd>C-cC-p</kbd>),...  Highly recommended.
 
+### opam-switch-mode
+
+If you happen to work with several switches, it is recommended to install
+[opam-switch-mode][] (available in [NonGNU ELPA][] and [MELPA][]).
+This minor mode defines a command <kbd>M-x opam-switch-set-switch</kbd>
+as well as a menu-bar and a mode-bar menu "OPSW",
+to easily select another OPAM switch. Upon such a change, a hook kills
+the running OCaml toplevel, if any, so that the next eval command
+is run using the OCaml toplevel from the new switch.
+
 ### Caml mode
 
 [caml-mode][] (available in [NonGNU ELPA][] and [MELPA][]) is used to
@@ -252,6 +262,7 @@ the obsolete `*.annot` files), open a module for documentation,...
 [caml-mode]: https://github.com/ocaml/caml-mode
 [NonGNU ELPA]: https://elpa.nongnu.org/
 [MELPA]: https://melpa.org/
+[opam-switch-mode]: https://github.com/ProofGeneral/opam-switch-mode
 
 
 Reporting

--- a/tuareg-opam.el
+++ b/tuareg-opam.el
@@ -386,7 +386,6 @@ Delegate the task to `opam-switch-set-switch' if the minor mode
 `opam-switch-mode' (https://github.com/ProofGeneral/opam-switch-mode)
 is installed. This ELPA package also provides a menu-bar and a
 mode-bar menu `\"OPSW\"'."
-  (declare (obsolete opam-switch-set-switch "2023-07"))
   (interactive
    (let* ((compl (tuareg-opam-installed-compilers))
           (current (tuareg-opam-current-compiler))

--- a/tuareg.el
+++ b/tuareg.el
@@ -1495,7 +1495,7 @@ Run only once."
     (define-key map "\C-c\C-c" #'compile)
     (define-key map "\C-c\C-w" (if (fboundp 'opam-switch-set-switch)
                                    #'opam-switch-set-switch
-                                 'tuareg-opam-update-env))
+                                 #'tuareg-opam-update-env))
     (define-key map "\M-\C-x" #'tuareg-eval-phrase)
     (define-key map "\C-x\C-e" #'tuareg-eval-phrase)
     (define-key map "\C-c\C-e" #'tuareg-eval-phrase)


### PR DESCRIPTION
This makes it possible to:

* keep the "C-c C-w" key-binding within tuareg
* don't trigger a fatal warning at byte-comp because of that
* see `opam-switch-mode` as a recommended, albeit optional dependency