### PR TITLE
Check if tuareg-opam--flymake-proc-allowed-file-name-masks is bound

### DIFF
--- a/tuareg-opam.el
+++ b/tuareg-opam.el
@@ -222,6 +222,7 @@ See `prettify-symbols-alist' for more information.")
 ;;;;                           Linting
 
 (require 'flymake)
+(require 'flymake-proc nil :noerror)
 
 (defalias 'tuareg-opam--flymake-proc-init-create-temp-buffer-copy
   (if (fboundp 'flymake-proc-init-create-temp-buffer-copy)
@@ -317,8 +318,9 @@ characters \\([0-9]+\\)-\\([0-9]+\\): +\\([^\n]*\\)$"
   (defvar tuareg-opam--flymake-proc-allowed-file-name-masks)
   (defvar tuareg-opam--flymake-proc-err-line-patterns)
 
-  (push tuareg-opam--allowed-file-name-masks
-        tuareg-opam--flymake-proc-allowed-file-name-masks)
+  (when (boundp 'tuareg-opam--flymake-proc-allowed-file-name-masks)
+    (push tuareg-opam--allowed-file-name-masks
+          tuareg-opam--flymake-proc-allowed-file-name-masks))
   (setq-local tuareg-opam--flymake-proc-err-line-patterns
               tuareg-opam--err-line-patterns)
   (when (and tuareg-opam-flymake buffer-file-name)


### PR DESCRIPTION
Since https://git.savannah.gnu.org/cgit/emacs.git/commit/?h=emacs-29&id=fe9dc7a087ad2b1ac94d32f975f649a2d7dfeb65 the variable is defined in `flymake-proc`, that is not required by default.  The consequence is that a "Void symbol" error is thrown whenever I open an `.opam` file.  This is a quick attempt at fixing the issue, that appears to resolve the issue on my end.