### PR TITLE
Stop tuareg from overwriting prettify-symbols-alist

### DIFF
--- a/tuareg.el
+++ b/tuareg.el
@@ -3198,10 +3198,12 @@ file outside _build? "))
     (add-function :around (local 'show-paren-data-function)
                   #'tuareg--show-paren))
   (setq prettify-symbols-alist
-        (if tuareg-prettify-symbols-full
-            (append tuareg-prettify-symbols-basic-alist
-                    tuareg-prettify-symbols-extra-alist)
-          tuareg-prettify-symbols-basic-alist))
+	;; preserve previous alist
+        (append prettify-symbols-alist
+		(if tuareg-prettify-symbols-full
+		    (append tuareg-prettify-symbols-basic-alist
+			    tuareg-prettify-symbols-extra-alist)
+		  tuareg-prettify-symbols-basic-alist)))
   (when (boundp 'prettify-symbols-compose-predicate) ; Emacs 25 or later
     (setq prettify-symbols-compose-predicate
           #'tuareg--prettify-symbols-compose-p))


### PR DESCRIPTION
Self explanatory.
I would like to be able to define my own prettify-symbols-alist elsewhere and not have tuareg overwrite it.
This may be a breaking change, so I'd be happy to hide it behind a feature of some sort, but by the fact that I would expect this to be the default behavior, I'd hope it wouldn't surprise anyone. 