### PR TITLE
Run CI on Emacs 29. Fix Emacs 26 compatibility snag.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
         emacs_version:
           - "26.3"
           - "27.2"
-          - "28.1"
+          - "28.2"
+          - "29.1"
           - snapshot
     steps:
       - name: Set up Emacs

--- a/ocamldebug.el
+++ b/ocamldebug.el
@@ -779,7 +779,7 @@ See also https://dune.readthedocs.io/en/latest/dune-files.html
         (let* ((contents (ocamldebug--read-from-file dune))
                (lib (and contents (ocamldebug--find-single-library contents)))
                (is-wrapped
-                (and lib (null (seq-contains-p lib '(wrapped false)))))
+                (and lib (null (member '(wrapped false) lib))))
                (libname (and is-wrapped (ocamldebug--dune-library-name lib))))
           (if libname
               (concat libname "__" (ocamldebug--upcase-first-char mod))


### PR DESCRIPTION
What it says on the tin.
The Emacs 26 incompatibility was introduced in 42539997a8aa98b683dd8b2b4973f4fe36050202.
