### PR TITLE
ocamldebug.el: Try and partially sync with `camldebug.el` (#227)

### DIFF
--- a/ocamldebug.el
+++ b/ocamldebug.el
@@ -83,7 +83,7 @@
   "If non-nil, always display current frame position in another window.")
 
 (defface ocamldebug-event
-  '((t :invert t))
+  '((t :inverse-video t))
   "Face to highlight the first/last char of current event."
   :group 'tuareg)
 

--- a/tuareg.el
+++ b/tuareg.el
@@ -1,7 +1,7 @@
 ;;; tuareg.el --- OCaml mode  -*- coding: utf-8; lexical-binding:t -*-
 
 ;; Copyright (C) 1997-2006 Albert Cohen, all rights reserved.
-;; Copyright (C) 2011-2023 Free Software Foundation, Inc.
+;; Copyright (C) 2011-2025 Free Software Foundation, Inc.
 ;; Copyright (C) 2009-2010 Jane Street Holding, LLC.
 
 ;; Author: Albert Cohen <Albert.Cohen@inria.fr>
@@ -371,7 +371,7 @@ Valid names are `browse-url', `browse-url-firefox', etc."
 (tuareg--obsolete-face-var tuareg-font-lock-constructor-face)
 
 (defface tuareg-font-lock-label-face
-  '((t (:inherit font-lock-constant-face keep)))
+  '((t (:inherit font-lock-constant-face))) ;; keep?
   "Face description for labels."
   :group 'tuareg-faces)
 (tuareg--obsolete-face-var tuareg-font-lock-label-face)


### PR DESCRIPTION
Add a binding to "backstep" by sync'ing with `camldebug.el`.

Align GPL version with that of `tuareg.el`.
Use `macroexp-file-name` when available.
Add `backstep` (C-k) and `display` (C-d) commands. 
(ocamldebug-track-frame): Mark it as a user option.
(ocamldebug-mode-map): Comment out broken `M-?` binding. 
(ocamldebug-mode): Make sure \\[..] refs are resolved relative to the mode map rather than the current map.
(def-ocamldebug): Prefer `when`.
(ocamldebug-complete-filter): Use `push`.
(ocamldebug-complete): Use `declare`.
(ocamldebug): Rename arg to `file`, to match the docstring. 
Try and behave a bit better when `make-comint` returns another buffer than the one we expected.
(ocamldebug-set-current-event): Remove `pos` argument. 
Use `before` instead (in the tty case) to decide whether to use `spos` or `epos`, like we already did in the GUI case.  Also, set `overlay-arrow-position` in the current buffer only. 
(ocamldebug-display-line): Adjust caller accordingly.