### PR TITLE
Add tuareg interface mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+* Introduce a new mode, `tuareg-interface-mode`.
 * Add support for [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode): you can enable the mode with <kbd>M-x opam-switch-mode</kbd> or add an automatic hook `(add-hook 'tuareg-mode-hook #'opam-switch-mode)`.
 * Fix keybindings to comply with [GNU Emacs' Key Binding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html) (unbind <kbd>C-c ?</kbd> as <kbd>C-c `</kbd> is already set; unbind <kbd>C-c C-h</kbd> and bind <kbd>C-h .</kbd> instead). See also [this issue](https://github.com/ocaml/merlin/issues/1386#issuecomment-1701567716).
 * Recognise identifiers containing non-ASCII (Unicode) letters.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 unreleased
 ----------
 
-* Introduce a new mode, `tuareg-interface-mode`.
 * Add support for [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode): you can enable the mode with <kbd>M-x opam-switch-mode</kbd> or add an automatic hook `(add-hook 'tuareg-mode-hook #'opam-switch-mode)`.
 * Fix keybindings to comply with [GNU Emacs' Key Binding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html) (unbind <kbd>C-c ?</kbd> as <kbd>C-c `</kbd> is already set; unbind <kbd>C-c C-h</kbd> and bind <kbd>C-h .</kbd> instead). See also [this issue](https://github.com/ocaml/merlin/issues/1386#issuecomment-1701567716).
 * Recognise identifiers containing non-ASCII (Unicode) letters.
+* Introduce a new mode, `tuareg-interface-mode`.
 
 3.0.1 2022-09-29
 ----------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ unreleased
 * Add support for [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode): you can enable the mode with <kbd>M-x opam-switch-mode</kbd> or add an automatic hook `(add-hook 'tuareg-mode-hook #'opam-switch-mode)`.
 * Fix keybindings to comply with [GNU Emacs' Key Binding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html) (unbind <kbd>C-c ?</kbd> as <kbd>C-c `</kbd> is already set; unbind <kbd>C-c C-h</kbd> and bind <kbd>C-h .</kbd> instead). See also [this issue](https://github.com/ocaml/merlin/issues/1386#issuecomment-1701567716).
 * Recognise identifiers containing non-ASCII (Unicode) letters.
-* Introduce a new mode, `tuareg-interface-mode`.
+* ⚠ Introduce a new mode, `tuareg-interface-mode`, for `.mli` and `.eliomi` files.
+  Note that since these files are no longer in `tuareg-mode` directly, exact major-mode checks like `(eq major-mode 'tuareg-mode)` in user configurations or third-party packages will now return nil in interface buffers. Use `(derived-mode-p 'tuareg-mode)` instead.
 
 3.0.1 2022-09-29
 ----------------

--- a/tuareg-compat.el
+++ b/tuareg-compat.el
@@ -8,7 +8,7 @@
 ;; Emacs < 26
 (defun tuareg--comment-padright--advice (orig-fun &rest args)
   (let ((str (nth 0 args)))
-    (unless (and (eq major-mode 'tuareg-mode)
+    (unless (and (derived-mode-p 'tuareg-mode)
                  (stringp str) (not (string-match "\\S-" str)))
       (apply orig-fun args))))
 
@@ -87,7 +87,7 @@
 	 indent))))))
 
 (defun tuareg--comment-region-default--advice (orig-fun &rest args)
-  (apply (if (eq major-mode 'tuareg-mode)
+  (apply (if (derived-mode-p 'tuareg-mode)
              'tuareg--comment-region-default
            orig-fun)
          args))
@@ -184,7 +184,7 @@ out."
 	 indent))))))
 
 (defun tuareg--comment-region-default-1--advice (orig-fun &rest args)
-  (apply (if (eq major-mode 'tuareg-mode)
+  (apply (if (derived-mode-p 'tuareg-mode)
              'tuareg--comment-region-default-1
            orig-fun)
          args))
@@ -296,7 +296,7 @@ This function is the default value of `uncomment-region-function'."
   (set-marker end nil))
 
 (defun tuareg--uncomment-region-default--advice (orig-fun &rest args)
-  (apply (if (eq major-mode 'tuareg-mode)
+  (apply (if (derived-mode-p 'tuareg-mode)
              'tuareg--uncomment-region-default
            orig-fun)
          args))
@@ -414,7 +414,7 @@ This function is the default value of `uncomment-region-function'."
   (set-marker end nil))
 
 (defun tuareg--uncomment-region-default-1--advice (orig-fun &rest args)
-  (apply (if (eq major-mode 'tuareg-mode)
+  (apply (if (derived-mode-p 'tuareg-mode)
              'tuareg--uncomment-region-default-1
            orig-fun)
          args))

--- a/tuareg-tests.el
+++ b/tuareg-tests.el
@@ -802,5 +802,13 @@ the original code."
                           "         theta iota\n")))
   )
 
+(ert-deftest tuareg-interface-mode-test ()
+  (with-temp-buffer
+    (setq buffer-file-name "test.mli")
+    (tuareg-interface-mode)
+    (should (derived-mode-p 'tuareg-mode))
+    (should (eq major-mode 'tuareg-interface-mode))
+    (should (equal (car mode-name) 'tuareg--other-file))
+    (should-not (fboundp 'tuareg--redirect-to-interface-mode))))
 
 (provide 'tuareg-tests)

--- a/tuareg.el
+++ b/tuareg.el
@@ -3330,17 +3330,10 @@ Short cuts for interactions with the REPL:
 ;;;###autoload
 (define-derived-mode tuareg-interface-mode tuareg-mode "Tuareg-Interface"
   "Major mode for editing OCaml interface (.mli) files."
-  (run-mode-hooks 'tuareg-load-hook))
-
-(defun tuareg--redirect-to-interface-mode ()
-  "Redirect .mli and .eliomi files to `tuareg-interface-mode'."
-  (when (and buffer-file-name
-             (or (string-suffix-p ".mli" buffer-file-name)
-                 (string-suffix-p ".eliomi" buffer-file-name))
-             (eq major-mode 'tuareg-mode))
-    (tuareg-interface-mode)))
-
-(add-hook 'tuareg-mode-hook #'tuareg--redirect-to-interface-mode)
+  (setq mode-name
+        '(tuareg--other-file
+          ("" "Tuareg-Interface" "[+" tuareg--other-file "]")
+          "Tuareg-Interface")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                               Error processing

--- a/tuareg.el
+++ b/tuareg.el
@@ -3216,8 +3216,10 @@ file outside _build? "))
             #'tuareg--electric-indent-predicate nil t)
   (add-hook 'post-self-insert-hook #'tuareg--electric-close-vector nil t))
 
-;;;###autoload(add-to-list 'auto-mode-alist '("\\.ml[ip]?\\'" . tuareg-mode))
-;;;###autoload(add-to-list 'auto-mode-alist '("\\.eliomi?\\'" . tuareg-mode))
+;;;###autoload(add-to-list 'auto-mode-alist '("\\.mli\\'" . tuareg-interface-mode))
+;;;###autoload(add-to-list 'auto-mode-alist '("\\.ml[p]?\\'" . tuareg-mode))
+;;;###autoload(add-to-list 'auto-mode-alist '("\\.eliomi\\'" . tuareg-interface-mode))
+;;;###autoload(add-to-list 'auto-mode-alist '("\\.eliom\\'" . tuareg-mode))
 ;;;###autoload(dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi"
 ;;;###autoload                ".annot" ".cmt" ".cmti"))
 ;;;###autoload  (add-to-list 'completion-ignored-extensions ext))
@@ -3324,6 +3326,21 @@ Short cuts for interactions with the REPL:
 ;; `caml-mode', for the purpose of tools like Eglot, YASnippet, etc...
 (when (fboundp 'derived-mode-add-parents) ;Emacs≥30
   (derived-mode-add-parents 'tuareg-mode '(caml-mode)))
+
+;;;###autoload
+(define-derived-mode tuareg-interface-mode tuareg-mode "Tuareg-Interface"
+  "Major mode for editing OCaml interface (.mli) files."
+  (run-mode-hooks 'tuareg-load-hook))
+
+(defun tuareg--redirect-to-interface-mode ()
+  "Redirect .mli and .eliomi files to `tuareg-interface-mode'."
+  (when (and buffer-file-name
+             (or (string-suffix-p ".mli" buffer-file-name)
+                 (string-suffix-p ".eliomi" buffer-file-name))
+             (eq major-mode 'tuareg-mode))
+    (tuareg-interface-mode)))
+
+(add-hook 'tuareg-mode-hook #'tuareg--redirect-to-interface-mode)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                               Error processing


### PR DESCRIPTION
## Purpose
This PR introduces a new major-mode for `.mli` and `.eliomi` files: `tuareg-interface-mode`
The necessity for this change comes from working on adding support for OCaml navigation in [Combobulate](https://github.com/mickeynp/combobulate). 

## Background
Tuareg uses one major-mode for `.mli` and `.ml` files, of which both file types have a separate tree-sitter grammar.
In Combobulate, we define two combobulate languages: `ocaml` and `ocaml-interface`, to handle both file types.
However, since with Tuareg we have a single major-mode for both file types, this led to an issue where when we activate Combobulate, the wrong parser is created in the buffer, as both parsers are able to attach to `tuareg-mode`. Introducing a new `tuareg-interface-mode` means we can disambiguate the Combobulate languages based on what the major mode is.

## Method
By taking advantage of Emacs' standard `define-derived-mode` macro, we have defined `tuareg-interface-mode` as a child mode of `tuareg-mode`. Because of how Emacs constructs derived modes:

- `tuareg-interface-mode` will automatically inherit all parent behaviors (indentation engine, syntax tables, highlighting configurations, font-locks, and the keymap `tuareg-mode-map`).
- It will automatically execute `tuareg-mode-hook` when loaded, meaning any existing third-party packages or user configurations (like LSP, Merlin, etc.) hooked into `tuareg-mode-hook` will continue working seamlessly for `.mli` files.
- It has its own `major-mode` value of `'tuareg-interface-mode` and runs `tuareg-interface-mode-hook`.
